### PR TITLE
Fixed bug in argument parsing

### DIFF
--- a/src/params.py
+++ b/src/params.py
@@ -247,6 +247,10 @@ def parse_args():
         help="Use the openai pretrained models.",
     )
     # arguments for distributed training
+    parser.add_argument("--distributed",
+        default=False,
+        action="store_true",
+        help="Whether to do distribute the training on multiple machines")
     parser.add_argument(
         "--dist-url",
         default="tcp://127.0.0.1:6100",


### PR DESCRIPTION
Without the parser argument added in this pull request--distributed can't be passed to the scripts.
This causes commands such as 
```
python src/eval_retrieval.py \
    --openai-pretrained \
    --resume /path/to/checkpoints \
    --eval-mode $data_name \ ## replace with coco, imgnet, or cirr
    --gpu $gpu_id
    --model ViT-L/14
```
 to fail when [this function](https://github.com/google-research/composed_image_retrieval/blob/8c053297c2fae9cd17ddcded48445a4f47208dbd/src/utils.py#LL50C1-L51C62) is called.